### PR TITLE
Fix for MW 1.31 and SMW 3.*

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ Semantic Tasks requires:
 
 * MediaWiki 1.23 or above
 * PHP 5.3 or above
-* Semantic MediaWiki 1.7 or above
+* Semantic MediaWiki 1.8 or above
 
 == Download ==
 
@@ -25,4 +25,4 @@ Once you have downloaded the code, place the ''SemanticTasks'' directory within 
 'extensions' directory. Then add the following code to your "LocalSettings.php" file:
 
 # Semantic Tasks
-require_once "$IP/extensions/SemanticTasks/SemanticTasks.php";
+wfLoadExtension( "SemanticTasks" );

--- a/ST_CheckForReminders.php
+++ b/ST_CheckForReminders.php
@@ -3,7 +3,7 @@
 # Licensed under the GNU GPLv2 (or later).
 
 $IP = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../..';
-require_once $IP . "/maintenance/maintenance.php";
+require_once $IP . "/maintenance/Maintenance.php";
 
 class CheckForReminders extends Maintenance {
 

--- a/SemanticTasks.classes.php
+++ b/SemanticTasks.classes.php
@@ -10,6 +10,8 @@ if ( !defined( 'SMW_VERSION' ) ) {
 	exit( 1 );
 }
 
+use SMW\DataValueFactory;
+
 // constants for message type
 define( 'NEWTASK', 0 );
 define( 'UPDATE', 1 );
@@ -421,7 +423,7 @@ class SemanticTasksMailer {
 		foreach ( $properties_to_display as $property ) {
 			if ( class_exists( 'SMWPropertyValue' ) ) { // SMW 1.4
 				$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_PROP, $property,
-					SMWPropertyValue::makeUserProperty( $property ) );
+					DataValueFactory::getInstance()->newPropertyValueByLabel( $property ) );
 			} else {
 				$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_PROP, $property,
 					Title::newFromText( $property, SMW_NS_PROPERTY ) );

--- a/SemanticTasks.classes.php
+++ b/SemanticTasks.classes.php
@@ -326,37 +326,37 @@ class SemanticTasksMailer {
 
 			/** @todo This should probably be refactored */
 			if ( $status == NEWTASK ) {
-				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-newtask' ) . ' ' .
+				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-newtask' )->text() . ' ' .
 					$title_text;
 				$message = 'semantictasks-newtask-msg';
-				$body = wfMessage( $message, $title_text ) . " " . $link;
-				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' ) . "\n" . $text;
+				$body = wfMessage( $message, $title_text )->text() . " " . $link;
+				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' )->text() . "\n" . $text;
 			} elseif ( $status == UPDATE ) {
-				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskupdated' ) . ' ' .
+				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskupdated' )->text() . ' ' .
 					$title_text;
 				$message = 'semantictasks-updatedtoyou-msg2';
-				$body = wfMessage( $message, $title_text ) . " " . $link;
-				$body .= "\n \n" . wfMessage( 'semantictasks-diff-message' ) . "\n" .
+				$body = wfMessage( $message, $title_text )->text() . " " . $link;
+				$body .= "\n \n" . wfMessage( 'semantictasks-diff-message' )->text() . "\n" .
 					self::generateDiffBodyTxt( $title );
 			} elseif ( $status == CLOSED ) {
-				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskclosed' ) . ' ' .
+				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskclosed' )->text() . ' ' .
 					$title_text;
 				$message = 'semantictasks-taskclosed-msg';
-				$body = wfMessage( $message, $title_text ) . " " . $link;
-				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' ) . "\n" . $text;
+				$body = wfMessage( $message, $title_text )->text() . " " . $link;
+				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' )->text() . "\n" . $text;
 			} elseif ( $status == UNASSIGNED ) {
-				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskunassigned' ) . ' ' .
+				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskunassigned' )->text() . ' ' .
 					$title_text;
 				$message = 'semantictasks-unassignedtoyou-msg2';
-				$body = wfMessage( $message, $title_text ) . " " . $link;
-				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' ) . "\n" . $text;
+				$body = wfMessage( $message, $title_text )->text() . " " . $link;
+				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' )->text() . "\n" . $text;
 			} else {
 				// status == ASSIGNED
-				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskassigned' ) . ' ' .
+				$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-taskassigned' )->text() . ' ' .
 					$title_text;
 				$message = 'semantictasks-assignedtoyou-msg2';
-				$body = wfMessage( $message, $title_text ) . " " . $link;
-				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' ) . "\n" . $text;
+				$body = wfMessage( $message, $title_text )->text() . " " . $link;
+				$body .= "\n \n" . wfMessage( 'semantictasks-text-message' )->text() . "\n" . $text;
 			}
 
 			$user_mailer = new UserMailer();
@@ -472,7 +472,7 @@ class SemanticTasksMailer {
 
 		while ( $row = $results->getNext() ) {
 			$task_name = $row[0]->getNextObject()->getTitle();
-			$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-reminder' ) . $task_name;
+			$subject = '[' . $wgSitename . '] ' . wfMessage( 'semantictasks-reminder' )->text() . $task_name;
 			// The following doesn't work, maybe because we use a cron job.
 			// $link = $task_name->getFullURL();
 			// So let's do it manually

--- a/SemanticTasks.php
+++ b/SemanticTasks.php
@@ -1,15 +1,5 @@
 <?php
 
-// Ensure that the script cannot be executed outside of MediaWiki.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'This is an extension to MediaWiki and cannot be run standalone.' );
-}
-
-// Ensure that Semantic MediaWiki is installed.
-if ( !defined( 'SMW_VERSION' ) ) {
-	die( 'This extension requires Semantic MediaWiki to be installed.' );
-}
-
 // This is the path to your installation of SemanticTasks as seen from the web.
 // Change it if required ($wgScriptPath is the path to the base directory of
 // your wiki). No final slash. It appears to be unused.
@@ -17,29 +7,3 @@ $stScriptPath = $wgScriptPath . '/extensions/SemanticTasks';
 
 // Set to true to notify users when they are unassigned from a task
 $wgSemanticTasksNotifyIfUnassigned = false;
-
-// Display extension properties on MediaWiki.
-$wgExtensionCredits['semantic'][] = array(
-	'path' => __FILE__,
-	'name' => 'SemanticTasks',
-	'author' => array(
-		'Steren Giannini',
-		'Ryan Lane',
-		'Ike Hecht',
-		'...'
-	),
-	'version' => '1.7.0',
-	'url' => 'https://www.mediawiki.org/wiki/Extension:Semantic_Tasks',
-	'descriptionmsg' => 'semantictasks-desc',
-	'license-name' => 'GPL-2.0-or-later'
-);
-
-// Register extension messages and other localisation.
-$wgMessagesDirs['SemanticTasks'] = __DIR__ . '/i18n';
-
-// Load extension's classes.
-$wgAutoloadClasses['SemanticTasksMailer'] = __DIR__ . '/SemanticTasks.classes.php';
-
-// Register extension hooks.
-$wgHooks['PageContentSaveComplete'][] = 'SemanticTasksMailer::mailAssigneesUpdatedTask';
-$wgHooks['PageContentSave'][] = 'SemanticTasksMailer::findOldValues';

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,29 @@
 {
+	"name": "mediawiki/semanitic-tasks",
+	"type": "mediawiki-extension",
+	"keywords": [
+		"smw",
+		"semantic mediawiki",
+		"wiki",
+		"mediawiki"
+	],
+	"homepage": "https://www.mediawiki.org/wiki/Extension:Semantic_Tasks",
+	"license": "GPL-2.0-or-later",
 	"require": {
-		"mediawiki/semantic-media-wiki": ">=1.7"
+		"mediawiki/semantic-media-wiki": ">=1.8",
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "1.0.0",
 		"jakub-onderka/php-console-highlighter": "0.3.2",
 		"mediawiki/minus-x": "0.3.1"
+	},
+	"autoload": {
+		"files": [
+			"SemanticTasks.php"
+		],
+		"classmap": [
+			"SemanticTasks.classes.php"
+		]
 	},
 	"scripts": {
 		"test": [

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,32 @@
+{
+	"name": "SemanticTasks",
+	"version": "1.7.0",
+	"author": [
+		"Steren Giannini",
+		"Ryan Lane",
+		"Ike Hecht",
+		"Peter Grassberger",
+		"..."
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:Semantic_Tasks",
+	"descriptionmsg": "semantictasks-desc",
+	"license-name": "GPL-2.0-or-later",
+	"type": "semantic",
+	"requires": {
+		"MediaWiki": ">= 1.23"
+	},
+	"MessagesDirs": {
+		"SemanticTasks": [
+			"i18n"
+		]
+	},
+	"AutoloadClasses": {
+		"SemanticTasksMailer": "SemanticTasks.classes.php"
+	},
+	"Hooks": {
+		"PageContentSaveComplete": "SemanticTasksMailer::mailAssigneesUpdatedTask",
+		"PageContentSave": "SemanticTasksMailer::findOldValues"
+	},
+	"load_composer_autoloader": true,
+	"manifest_version": 1
+}

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticTasks",
-	"version": "1.7.0",
+	"version": "2.0.0-alpha",
 	"author": [
 		"Steren Giannini",
 		"Ryan Lane",


### PR DESCRIPTION
Tested with the following markup which triggers an email notification on 2019-04-25T10:00:00Z when the cronjob runs:
```
[[Assigned to::User:Admin]]
[[Reminder at::2019-04-25T10:00:00Z]]
[[Target date::2019-04-25T10:00:00Z]]
[[Status::In Progress]]
```

Also when setting `[[Assigned to::User:Admin]]` an E-Mail is sent to the Admin User immediately.

This PR mostly replaces deprecated function calls.

@krabina please check if it works on your setup or provide me with Wiki markup that you use for your tasks that should get an email notification. So that I can test it more.