### PR TITLE
Drop support for SMW 1.7.x

### DIFF
--- a/ST_CheckForReminders.php
+++ b/ST_CheckForReminders.php
@@ -3,7 +3,7 @@
 # Licensed under the GNU GPLv2 (or later).
 
 $IP = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../..';
-require_once $IP . "/maintenance/maintenance.php";
+require_once $IP . "/maintenance/Maintenance.php";
 
 class CheckForReminders extends Maintenance {
 

--- a/SemanticTasks.classes.php
+++ b/SemanticTasks.classes.php
@@ -10,6 +10,8 @@ if ( !defined( 'SMW_VERSION' ) ) {
 	exit( 1 );
 }
 
+use SMW\DataValueFactory;
+
 // constants for message type
 define( 'NEWTASK', 0 );
 define( 'UPDATE', 1 );
@@ -421,7 +423,7 @@ class SemanticTasksMailer {
 		foreach ( $properties_to_display as $property ) {
 			if ( class_exists( 'SMWPropertyValue' ) ) { // SMW 1.4
 				$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_PROP, $property,
-					SMWPropertyValue::makeUserProperty( $property ) );
+					DataValueFactory::getInstance()->newPropertyValueByLabel( $property ) );
 			} else {
 				$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_PROP, $property,
 					Title::newFromText( $property, SMW_NS_PROPERTY ) );

--- a/SemanticTasks.classes.php
+++ b/SemanticTasks.classes.php
@@ -406,39 +406,23 @@ class SemanticTasksMailer {
 		// We use the Semantic MediaWiki Processor
 		$params = array();
 		$inline = true;
-		$printlabel = "";
 		$printouts = array();
 
 		// add the page name to the printouts
 		if ( $display_title ) {
-			if ( version_compare( SMW_VERSION, '1.7', '>' ) ) {
-				SMWQueryProcessor::addThisPrintout( $printouts, $params );
-			} else {
-				$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_THIS, $printlabel );
-				array_push( $printouts, $to_push );
-			}
+			SMWQueryProcessor::addThisPrintout( $printouts, $params );
 		}
 
 		// Push the properties to display in the printout array.
 		foreach ( $properties_to_display as $property ) {
-			if ( class_exists( 'SMWPropertyValue' ) ) { // SMW 1.4
-				$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_PROP, $property,
-					DataValueFactory::getInstance()->newPropertyValueByLabel( $property ) );
-			} else {
-				$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_PROP, $property,
-					Title::newFromText( $property, SMW_NS_PROPERTY ) );
-			}
+			$to_push = new SMWPrintRequest( SMWPrintRequest::PRINT_PROP, $property,
+				DataValueFactory::getInstance()->newPropertyValueByLabel( $property ) );
 			array_push( $printouts, $to_push );
 		}
 
-		if ( version_compare( SMW_VERSION, '1.6.1', '>' ) ) {
-			$params = SMWQueryProcessor::getProcessedParams( $params, $printouts );
-			$format = null;
-		} else {
-			$format = 'auto';
-		}
+		$params = SMWQueryProcessor::getProcessedParams( $params, $printouts );
 
-		$query = SMWQueryProcessor::createQuery( $query_string, $params, $inline, $format, $printouts );
+		$query = SMWQueryProcessor::createQuery( $query_string, $params, $inline, null, $printouts );
 		$results = smwfGetStore()->getQueryResult( $query );
 
 		return $results;


### PR DESCRIPTION
Depends on https://github.com/SemanticMediaWiki/SemanticTasks/pull/1

Compatibility was already noted to start at 1.8.x in several places (wiki, code, etc.). This PR just removes code dealing with older versions.