### PR TITLE
Adds missing "namemsg" system message

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -10,6 +10,7 @@
 	],
 	"url": "https://www.mediawiki.org/wiki/Extension:Semantic_Tasks",
 	"descriptionmsg": "semantictasks-desc",
+	"namemsg": "semantictasks-name",
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,10 +1,13 @@
 {
 	"@metadata": {
 		"authors": [
-			"Steren Giannini"
+			"Kghbln",
+			"Steren Giannini",
+			"Tosfos"
 		]
 	},
-	"semantictasks-desc": "Email notifications for assigned or updated tasks",
+	"semantictasks-desc": "Sends email notifications for assigned or updated tasks",
+	"semantictasks-name": "Semantic Tasks",	
 	"semantictasks-newtask": "New task:",
 	"semantictasks-taskassigned": "Task assigned:",
 	"semantictasks-taskunassigned": "Task unassigned:",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -2,12 +2,14 @@
 	"@metadata": {
 		"authors": [
 			"Fryed-peach",
+			"Kghbln",
 			"Purodha",
 			"Shirayuki",
 			"Umherirrender"
 		]
 	},
 	"semantictasks-desc": "{{desc|name=Semantic Tasks|url=https://www.mediawiki.org/wiki/Extension:Semantic_Tasks}}",
+	"semantictasks-name": "{{notranslate}}\n\nName of the extension as it should be displayed.",
 	"semantictasks-newtask": "Used in a notification mail",
 	"semantictasks-taskassigned": "Used in a notification mail",
 	"semantictasks-taskunassigned": "Used in a notification mail",


### PR DESCRIPTION
This PR addresses or contains:
- Adds missing "namemsg" system message for displaying the extension's name on Special:Version 

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
