### PR TITLE
make checkForReminders respect quiet parameter, move to folder #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You must run a cron job once a day to execute the reminder script:
     * edit your crontab file: 
         $ crontab -e
     * add the following line to execute the script every day at 12: 
-        0 12 * * * php extensions/SemanticTasks/ST_CheckForReminders.php
+        0 12 * * * php extensions/SemanticTasks/maintenance/checkForReminders.php
 
 ## Contact
 

--- a/maintenance/checkForReminders.php
+++ b/maintenance/checkForReminders.php
@@ -2,16 +2,17 @@
 # (C) 2008 Steren Giannini
 # Licensed under the GNU GPLv2 (or later).
 
-$IP = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../..';
+$IP = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 require_once $IP . "/maintenance/Maintenance.php";
 
 class CheckForReminders extends Maintenance {
 
 	public function execute() {
-		require_once __DIR__ . '/SemanticTasks.classes.php';
-		// Let's send reminders
+		require_once __DIR__ . '/../SemanticTasks.classes.php';
+		if ( !$this->isQuiet() ) {
+			print "ST check for reminders\n";
+		}
 		SemanticTasksMailer::remindAssignees();
-		print "ST check for reminders\n";
 	}
 }
 


### PR DESCRIPTION
This PR is made in reference to: #8

This PR addresses or contains:
- rename script to `checkForReminders.php`
- move script to `maintenance` folder
- respect `quiet` parameter

The `remindAssignees` function still contains some `printDebug` commands that print when `$wgSemanticTasksDebug` is true even with the `quiet` parameter.