### PR TITLE
WIP Bugfix: Send mail to users on new page (and task) creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       php: 7.2
     - env: DB=mysql; MW=REL1_32; SMW=~3.1@dev
       php: 7.2
-    - env: DB=postgres; MW=REL1_33; SMW=~3.0
+    - env: DB=postgres; MW=REL1_31; SMW=~3.0.0
       php: 7.2
     - env: DB=postgres; MW=REL1_33; SMW=~3.1@dev; TYPE=coverage
       php: 7.3

--- a/SemanticTasks.php
+++ b/SemanticTasks.php
@@ -72,11 +72,11 @@ class SemanticTasks {
 		// Register extension hooks.
 		global $wgHooks;
 		$wgHooks['PageContentSave'][] = [ $assignees, 'saveAssignees' ];
-		$wgHooks['PageContentSaveComplete'][] = function(WikiPage $article, User $current_user, $text,
-				$summary, $minoredit, $watchthis, $sectionanchor, $flags) use ($assignees) {
+		$wgHooks['PageContentSaveComplete'][] = function(WikiPage $article, User $current_user, Content $text,
+				$summary, $minoredit, $watchthis, $sectionanchor, $flags, $revision) use ($assignees) {
 			SemanticTasksMailer::mailAssigneesUpdatedTask(
 				$assignees, $article, $current_user, $text,
-				$summary, $minoredit, $watchthis, $sectionanchor, $flags
+				$summary, $minoredit, $watchthis, $sectionanchor, $flags, $revision
 			);
 		};
 	}

--- a/src/Assignees.php
+++ b/src/Assignees.php
@@ -144,12 +144,15 @@ class Assignees {
 	 * @param array $assignees
 	 * @return array
 	 */
-	public function getAssigneeAddresses( array $assignees ) {
+	public static function getAssigneeAddresses( array $assignees ) {
 		$assignee_arr = array();
 		foreach ( $assignees as $assignee_name ) {
 			$assignee = User::newFromName( $assignee_name );
 			// if assignee is the current user, do nothing
 			# if ( $assignee->getID() != $user->getID() ) {
+			if (!$assignee) {
+				continue;
+			}
 			$assignee_mail = new \MailAddress( $assignee->getEmail(), $assignee_name );
 			array_push( $assignee_arr, $assignee_mail );
 			# }

--- a/src/Assignees.php
+++ b/src/Assignees.php
@@ -149,7 +149,7 @@ class Assignees {
 	 * @param array $assignees
 	 * @return array
 	 */
-	public static function getAssigneeAddresses( array $assignees ) {
+	static public function getAssigneeAddresses( array $assignees ) {
 		$assignee_arr = array();
 		foreach ( $assignees as $assignee_name ) {
 			$assignee = User::newFromName( $assignee_name );

--- a/src/Assignees.php
+++ b/src/Assignees.php
@@ -2,6 +2,10 @@
 
 namespace ST;
 
+use ParserOutput;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+use SMWDataItem;
 use User;
 use WikiPage;
 
@@ -18,8 +22,8 @@ class Assignees {
 	 * @return bool
 	 */
 	public function saveAssignees( WikiPage &$article ) {
-		$this->taskAssignees = $this->getCurrentAssignees( $article );
-		$this->taskStatus = $this->getCurrentStatus( $article );
+		$this->taskAssignees = $this->getCurrentAssignees( $article, null );
+		$this->taskStatus = $this->getCurrentStatus( $article, null );
 		return true;
 	}
 
@@ -33,28 +37,27 @@ class Assignees {
 
 	/**
 	 * @param WikiPage $article
+	 * @param $revision
 	 * @return array
 	 */
-	public function getCurrentAssignees( WikiPage &$article ) {
+	public function getCurrentAssignees( WikiPage &$article, $revision ) {
 		global $stgPropertyAssignedTo;
-		$titleText = $article->getTitle()->getFullText();
-		return $this->getAssignees( $stgPropertyAssignedTo, $titleText );
+		return $this->getProperties( $stgPropertyAssignedTo, $article, $revision );
 	}
 
-	public function getCurrentCarbonCopy( WikiPage &$article ) {
+	public function getCurrentCarbonCopy( WikiPage &$article, $revision ) {
 		global $stgPropertyCarbonCopy;
-		$titleText = $article->getTitle()->getFullText();
-		return $this::getAssignees( $stgPropertyCarbonCopy, $titleText );
+		return $this->getProperties( $stgPropertyCarbonCopy, $article, $revision );
 	}
 
 	/**
 	 * @param WikiPage $article
+	 * @param $revision
 	 * @return string
 	 */
-	public function getCurrentStatus( WikiPage &$article ) {
+	public function getCurrentStatus( WikiPage &$article, $revision ) {
 		global $stgPropertyStatus;
-		$titleText = $article->getTitle()->getFullText();
-		$status = $this->getStatus( $stgPropertyStatus, $titleText );
+		$status = $this->getProperties( $stgPropertyStatus, $article, $revision );
 		$statusString = '';
 		if ( count( $status ) > 0 ) {
 			$statusString = $status[0];
@@ -64,18 +67,20 @@ class Assignees {
 
 	/**
 	 * @param WikiPage $article
+	 * @param $revision
 	 * @return array
 	 */
-	public function getNewAssignees( WikiPage &$article ) {
-		return array_diff( $this->getCurrentAssignees( $article ), $this->taskAssignees );
+	public function getNewAssignees( WikiPage &$article, $revision ) {
+		return array_diff( $this->getCurrentAssignees( $article, $revision ), $this->taskAssignees );
 	}
 
 	/**
 	 * @param WikiPage $article
+	 * @param $revision
 	 * @return array
 	 */
-	public function getRemovedAssignees( WikiPage &$article ) {
-		return array_diff( $this->taskAssignees, $this->getCurrentAssignees( $article ) );
+	public function getRemovedAssignees( WikiPage &$article, $revision ) {
+		return array_diff( $this->taskAssignees, $this->getCurrentAssignees( $article, $revision ) );
 	}
 
 	/**
@@ -164,75 +169,54 @@ class Assignees {
 	/**
 	 * Returns an array of properties based on $query_word
 	 *
-	 * @param string $query_word The property that designate the users to notify.
-	 * @param string $title_text
+	 * @param string $propertyString The property that designate the users to notify.
+	 * @param WikiPage $article
+	 * @param $revision
 	 * @return array
 	 */
-	private function getAssignees( $query_word, $title_text ) {
-		// Array of assignees to return
-		$assignee_arr = array();
+	private function getProperties( $propertyString, $article, $revision ) {
+		$smwFactory = ApplicationFactory::getInstance();
+		$mwCollaboratorFactory = $smwFactory->newMwCollaboratorFactory();
+		if ($revision === null) {
+			$revision = $article->getRevision();
+		}
+		if ($revision === null) {
+			return [];
+		}
+		if ( version_compare( SMW_VERSION, '3.1', '<' ) ) {
+			$editInfo = $mwCollaboratorFactory->newEditInfoProvider(
+				$article,
+				$revision,
+				null
+			);
+		} else {
+			$editInfo = $mwCollaboratorFactory->newEditInfo(
+				$article,
+				$revision,
+				null
+			);
+		}
+		$editInfo->fetchEditInfo();
+		$parserOutput = $editInfo->getOutput();
 
-		// get the result of the query "[[$title]][[$query_word::+]]"
-		$properties_to_display = array( $query_word );
-		$results = Query::getQueryResults( "[[$title_text]][[$query_word::+]]", $properties_to_display,
-			false );
-
-		$task_assignees = null;
-		// In theory, there is only one row
-		while ( $row = $results->getNext() ) {
-			$task_assignees = $row[0];
+		if ( !$parserOutput instanceof ParserOutput ) {
+			return [];
 		}
 
-		// If not any row, do nothing
-		if ( !empty( $task_assignees ) ) {
-			// since title is not displayed, 'Assigned to' value will be first value
-			$assignee_name = $task_assignees->getNextText( SMW_OUTPUT_WIKI );
-			/** @todo Create User object */
-			$assignee_name = explode( ":", $assignee_name );
+		$propertyStringUnderscores = str_replace( ' ', '_', $propertyString );
+		$property = new \SMW\DIProperty( $propertyStringUnderscores, false );
 
-			if ( !isset( $assignee_name[1] ) ) {
-				return array();
+		/** @var $semanticData \SMW\SemanticData */
+		$semanticData = $parserOutput->getExtensionData( 'smwdata' );
+		$propValues = $semanticData->getPropertyValues( $property );
+		$valueList = array_map(function( SMWDataItem $propVal ) {
+			if ($propVal instanceof DIWikiPage) {
+				return $propVal->getTitle()->getText();
 			}
+			return $propVal;
+		}, $propValues);
 
-			$assignee_name = $assignee_name[1];
-
-			array_push( $assignee_arr, $assignee_name );
-		}
-
-		return $assignee_arr;
-	}
-
-	/**
-	 * Returns an array of properties based on $query_word
-	 *
-	 * @param string $query_word The property that designate the users to notify.
-	 * @param string $title_text
-	 * @return array
-	 */
-	private function getStatus( $query_word, $title_text ) {
-		// Array of assignees to return
-		$assignee_arr = array();
-
-		// get the result of the query "[[$title]][[$query_word::+]]"
-		$properties_to_display = array();
-		$properties_to_display[0] = $query_word;
-		$results = Query::getQueryResults( "[[$title_text]][[$query_word::+]]", $properties_to_display,
-			false );
-
-		// In theory, there is only one row
-		while ( $row = $results->getNext() ) {
-			$task_assignees = $row[0];
-		}
-
-		// If not any row, do nothing
-		if ( !empty( $task_assignees ) ) {
-			while ( $task_assignee = $task_assignees->getNextObject() ) {
-				$assignee_name = $task_assignee->getWikiValue();
-				array_push( $assignee_arr, $assignee_name );
-			}
-		}
-
-		return $assignee_arr;
+		return $valueList;
 	}
 }
 

--- a/src/SemanticTasksMailer.php
+++ b/src/SemanticTasksMailer.php
@@ -69,29 +69,27 @@ class SemanticTasksMailer {
 		if ( ( $flags & EDIT_NEW ) && !$article->getTitle()->isTalkPage() ) {
 			$status = ST_NEWTASK;
 		}
-		$assignedToParserOutput = self::getAssignedUsersFromParserOutput($article, $revision, $current_user);
+		$assignedToParserOutput = self::getAssignedUsersFromParserOutput( $article );
 
 		return self::mailAssignees( $article, $text, $current_user, $status, $assignees, $assignedToParserOutput );
 	}
 
 	// todo: this could replace Assignees->getAssignees(...).
-	public static function getAssignedUsersFromParserOutput(WikiPage $article, $revision, User $current_user) {
-		if ( $revision === null) {
-			return [];
-		}
+	public static function getAssignedUsersFromParserOutput( WikiPage $article ) {
 		$smwFactory = ApplicationFactory::getInstance();
 		$mwCollaboratorFactory = $smwFactory->newMwCollaboratorFactory();
+		$revision = $article->getRevision();
 		if ( version_compare( SMW_VERSION, '3.1', '<' ) ) {
 			$editInfo = $mwCollaboratorFactory->newEditInfoProvider(
 				$article,
 				$revision,
-				$current_user
+				null
 			);
 		} else {
 			$editInfo = $mwCollaboratorFactory->newEditInfo(
 				$article,
 				$revision,
-				$current_user
+				null
 			);
 		}
 		$editInfo->fetchEditInfo();
@@ -102,14 +100,14 @@ class SemanticTasksMailer {
 		}
 
 		global $stgPropertyAssignedTo;
-		$stgPropertyAssignedToString = str_replace(' ', '_', $stgPropertyAssignedTo);
-		$property = new \SMW\DIProperty($stgPropertyAssignedToString, false);
+		$stgPropertyAssignedToString = str_replace( ' ', '_', $stgPropertyAssignedTo );
+		$property = new \SMW\DIProperty( $stgPropertyAssignedToString, false );
 
 		/** @var $semanticData \SMW\SemanticData */
-		$semanticData = $parserOutput->getExtensionData('smwdata');
-		$assigneesPropValues = $semanticData->getPropertyValues($property);
+		$semanticData = $parserOutput->getExtensionData( 'smwdata' );
+		$assigneesPropValues = $semanticData->getPropertyValues( $property );
 		// todo: maybe there should be a check if these pages are userpages.
-		$assigneeList = array_map(function(DIWikiPage $assignePropVal) {
+		$assigneeList = array_map(function( DIWikiPage $assignePropVal ) {
 			return $assignePropVal->getTitle()->getText();
 		}, $assigneesPropValues);
 

--- a/src/SemanticTasksMailer.php
+++ b/src/SemanticTasksMailer.php
@@ -69,20 +69,31 @@ class SemanticTasksMailer {
 		if ( ( $flags & EDIT_NEW ) && !$article->getTitle()->isTalkPage() ) {
 			$status = ST_NEWTASK;
 		}
-		$assignedToParserOutput = self::getAssignedUserFromParserOutput($article, $revision, $current_user);
+		$assignedToParserOutput = self::getAssignedUsersFromParserOutput($article, $revision, $current_user);
 
 		return self::mailAssignees( $article, $text, $current_user, $status, $assignees, $assignedToParserOutput );
 	}
 
 	// todo: this could replace Assignees->getAssignees(...).
-	private static function getAssignedUserFromParserOutput(WikiPage $article, $revision, User $current_user) {
+	public static function getAssignedUsersFromParserOutput(WikiPage $article, $revision, User $current_user) {
+		if ( $revision === null) {
+			return [];
+		}
 		$smwFactory = ApplicationFactory::getInstance();
 		$mwCollaboratorFactory = $smwFactory->newMwCollaboratorFactory();
-		$editInfo = $mwCollaboratorFactory->newEditInfo(
-			$article,
-			$revision,
-			$current_user
-		);
+		if ( version_compare( SMW_VERSION, '3.1', '<' ) ) {
+			$editInfo = $mwCollaboratorFactory->newEditInfoProvider(
+				$article,
+				$revision,
+				$current_user
+			);
+		} else {
+			$editInfo = $mwCollaboratorFactory->newEditInfo(
+				$article,
+				$revision,
+				$current_user
+			);
+		}
 		$editInfo->fetchEditInfo();
 		$parserOutput = $editInfo->getOutput();
 

--- a/tests/phpunit/Unit/SemanticTasksMailerTest.php
+++ b/tests/phpunit/Unit/SemanticTasksMailerTest.php
@@ -159,7 +159,7 @@ class SemanticTasksMailerTest extends \MediaWikiTestCase {
 		$article->doEditContent( $content, 'edit page' );
 		$revision = $article->getRevision();
 		$current_user = new User();
-		$assignendUsers = SemanticTasksMailer::getAssignedUsersFromParserOutput( $article, $revision, $current_user );
+		$assignendUsers = SemanticTasksMailer::getAssignedUsersFromParserOutput( $article );
 
 		$this->assertEmpty( $assignendUsers );
 	}

--- a/tests/phpunit/Unit/SemanticTasksMailerTest.php
+++ b/tests/phpunit/Unit/SemanticTasksMailerTest.php
@@ -151,6 +151,19 @@ class SemanticTasksMailerTest extends \MediaWikiTestCase {
 		$this->assertTrue($returnValue);
 	}
 
+	public function testGetAssignedUsersFromParserOutput() {
+		$namespace = $this->getDefaultWikitextNS();
+		$title = Title::newFromText( 'Some Random Page', $namespace );
+		$article = WikiPage::factory( $title );
+		$content = \ContentHandler::makeContent( 'this is some edit', $title );
+		$article->doEditContent( $content, 'edit page' );
+		$revision = $article->getRevision();
+		$current_user = new User();
+		$assignendUsers = SemanticTasksMailer::getAssignedUsersFromParserOutput( $article, $revision, $current_user );
+
+		$this->assertEmpty( $assignendUsers );
+	}
+
 	/** @todo: fix covers annotation and remove this. */
 	public function testValidCovers() {
 		$this->assertTrue( true );

--- a/tests/phpunit/Unit/SemanticTasksMailerTest.php
+++ b/tests/phpunit/Unit/SemanticTasksMailerTest.php
@@ -159,7 +159,8 @@ class SemanticTasksMailerTest extends \MediaWikiTestCase {
 		$article->doEditContent( $content, 'edit page' );
 		$revision = $article->getRevision();
 		$current_user = new User();
-		$assignendUsers = SemanticTasksMailer::getAssignedUsersFromParserOutput( $article );
+		$assignees = new Assignees();
+		$assignendUsers = $assignees->getCurrentAssignees( $article, $revision );
 
 		$this->assertEmpty( $assignendUsers );
 	}

--- a/tests/phpunit/Unit/SemanticTasksMailerTest.php
+++ b/tests/phpunit/Unit/SemanticTasksMailerTest.php
@@ -138,9 +138,10 @@ class SemanticTasksMailerTest extends \MediaWikiTestCase {
 		$watchthis = null; // unused
 		$sectionanchor = null; // unused
 		$flags = EDIT_NEW; // or other..
+		$revision = null;
 		try {
 			$returnValue = SemanticTasksMailer::mailAssigneesUpdatedTask( $assignees, $article, $current_user, $text,
-				$summary, $minoredit, $watchthis, $sectionanchor, $flags );
+				$summary, $minoredit, $watchthis, $sectionanchor, $flags, $revision );
 		} catch ( MWException $e ) {
 
 		} catch ( ComplexityException $e ) {

--- a/tests/travis/install-semantic-tasks.sh
+++ b/tests/travis/install-semantic-tasks.sh
@@ -4,11 +4,20 @@ set -ex
 BASE_PATH=$(pwd)
 MW_INSTALL_PATH=$BASE_PATH/../mw
 
+function installSMWWithComposer {
+	if [ "$SMW" != "" ]
+	then
+		composer require 'mediawiki/semantic-media-wiki='$SMW --update-with-dependencies
+	fi
+}
+
 # Run Composer installation from the MW root directory
 function installToMediaWikiRoot {
 	echo -e "Running MW root composer install build on $TRAVIS_BRANCH \n"
 
 	cd $MW_INSTALL_PATH
+
+	installSMWWithComposer
 
 	if [ "$PHPUNIT" != "" ]
 	then


### PR DESCRIPTION
~~WIP, don't merge yet.~~

This PR is made in reference to: #15 
~~This PR builds on #27 , so that one should me merged first or I'll need to extract the code.~~

I've written a function `SemanticTasksMailer->getAssignedUserFromParserOutput()` that gets the assigned users from `ParserOutput` instead of a `Query`. This function could totally replace `Assignees->getAssignees()`, for now I just use it if `getAssignees()` does not return any assignees (for example on new page creation). Seems to work, pushed it here to have it tested.