### PR TITLE
update to php 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ notification (see below).
 
 ## Requirements
 
- - PHP 5.6 or later
+ - PHP 7.2 or later
  - MediaWiki 1.31  or later
  - Semantic MediaWiki 3.0 or later
 


### PR DESCRIPTION
php 7.1 is only supported until 1 December 2019

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
