### PR TITLE
Moves `$wgSemanticTasksNotifyIfUnassigned` into `extension.json`

### DIFF
--- a/SemanticTasks.php
+++ b/SemanticTasks.php
@@ -44,10 +44,6 @@ class SemanticTasks {
 
 		// Register extension messages and other localisation.
 		$wgMessagesDirs['SemanticTasks'] = __DIR__ . '/i18n';
-
-		// Set to true to notify users when they are unassigned from a task
-		global $wgSemanticTasksNotifyIfUnassigned;
-		$wgSemanticTasksNotifyIfUnassigned = false;
 	}
 
 	/**

--- a/extension.json
+++ b/extension.json
@@ -38,6 +38,7 @@
 		"PropertyReminderAt": "Reminder at",
 		"PropertyStatus": "Status",
 		"PropertyAssignedToGroup": "Assigned to group",
-		"PropertyHasAssignee": "Has assignee"
+		"PropertyHasAssignee": "Has assignee",
+		"SemanticTasksNotifyIfUnassigned": false
 	}
 }


### PR DESCRIPTION
Fixes `$wgSemanticTasksNotifyIfUnassigned` being reseted to false on each init regardless of the actual variable value
