### PR TITLE
Allows fallback to system email from address

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ property names. This is the list of default settings:
 * `$stgPropertyAssignedToGroup = 'Assigned to group';`
 * `$stgPropertyHasAssignee = 'Has assignee';`
 
+## Configuration
+
+* `SemanticTasksNotifyIfUnassigned` - (default: `false`) If set to `true` will notify
+  users being unassigned from tasks
+* `$stgNotificationFromSystemAddress` - (default: `false`) If set to `true` will use
+  `$wgSiteName` and `$wgPasswordSender` for notification emails From field
+
 ## Usage
 
 Notification emails:  

--- a/extension.json
+++ b/extension.json
@@ -39,6 +39,7 @@
 		"PropertyStatus": "Status",
 		"PropertyAssignedToGroup": "Assigned to group",
 		"PropertyHasAssignee": "Has assignee",
-		"SemanticTasksNotifyIfUnassigned": false
+		"SemanticTasksNotifyIfUnassigned": false,
+		"NotificationFromSystemAddress": false
 	}
 }

--- a/src/SemanticTasksMailer.php
+++ b/src/SemanticTasksMailer.php
@@ -143,13 +143,16 @@ class SemanticTasksMailer {
 	 * @global string $wgSitename
 	 */
 	static function mailNotification( array $assignees, $text, Title $title, User $user, $status ) {
-		global $wgSitename;
+		global $wgSitename, $stgNotificationFromSystemAddress, $wgPasswordSender;
 
 		if ( empty( $assignees ) ) {
 			return;
 		}
 		$title_text = $title->getFullText();
-		$from = new \MailAddress( $user->getEmail(), $user->getName() );
+		$from = new \MailAddress(
+			$stgNotificationFromSystemAddress ? $wgPasswordSender : $user->getEmail(),
+			$stgNotificationFromSystemAddress ? $wgSitename : $user->getName()
+		);
 		$link = htmlspecialchars( $title->getFullURL() );
 
 		/** @todo This should probably be refactored */


### PR DESCRIPTION
This PR addresses or contains:

- Emails are always sent from the user being notified email address with no alternatives ignoring the `$wgSiteName` and `$wgPasswordSender`
- The PR introduces a new `$stgNotificationFromSystemAddress` configuration
variable (default `false`) which if set to `true` uses wiki `$wgSiteName` and `$wgPasswordSender` as a From address for
tasks notifications emails

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed ( Travis seems to be broken )
